### PR TITLE
fix(auth): authenticate against target when access token is unavailable

### DIFF
--- a/src/commands/execute-code/ExecuteCodeCommand.ts
+++ b/src/commands/execute-code/ExecuteCodeCommand.ts
@@ -51,7 +51,7 @@ export class ExecuteCodeCommand {
     if (!target) {
       return
     }
-    const accessToken = await getAccessToken(target)
+    const accessToken = await getAccessToken(target, this.outputChannel)
     const currentFileContent = getEditorContent()
 
     const adapter = new SASjs({


### PR DESCRIPTION
# Intent
Handle the scenario in which a target is present, but not authenticated.

# Implementation
* Modified `getAccessToken` to run through the auth flow in case an access token is not found for the selected target.