### PR TITLE
fix: invalid syntax for icon pack

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "languages": [
       {
         "id": "sas",
-        "icon": "./themes/sasjs-icon-round.png",
+        "icon": {
+          "dark": "./themes/sasjs-icon-round.png",
+          "light": "./themes/sasjs-icon-round.png"
+        },
         "aliases": [
           "SAS"
         ],


### PR DESCRIPTION
Fixing syntax highlighting for SAS programs