### PR TITLE
fix: Show auth code web link in console window in addition to redirect

### DIFF
--- a/src/commands/execute-code/internal/configuration.ts
+++ b/src/commands/execute-code/internal/configuration.ts
@@ -48,9 +48,12 @@ export const getAuthConfig = async (
   if (target.serverType === ServerType.SasViya) {
     clientSecret = await getClientSecret()
   }
-  env.openExternal(
-    Uri.parse(getAuthUrl(target.serverType, target.serverUrl, clientId))
+  const authUrl = Uri.parse(
+    getAuthUrl(target.serverType, target.serverUrl, clientId)
   )
+  outputChannel.appendLine(authUrl.toString())
+  outputChannel.show()
+  env.openExternal(authUrl)
   const authCode = await getAuthCode()
 
   const authResponse = await getTokens(

--- a/src/utils/createTarget.ts
+++ b/src/utils/createTarget.ts
@@ -31,7 +31,10 @@ export const createTarget = async (outputChannel: OutputChannel) => {
     const clientId = await getClientId()
     const clientSecret = await getClientSecret()
 
-    env.openExternal(Uri.parse(getAuthUrl(serverType, serverUrl, clientId)))
+    const authUrl = Uri.parse(getAuthUrl(serverType, serverUrl, clientId))
+    outputChannel.appendLine(authUrl.toString())
+    outputChannel.show()
+    env.openExternal(authUrl)
 
     const authCode = await getAuthCode()
 
@@ -60,7 +63,10 @@ export const createTarget = async (outputChannel: OutputChannel) => {
     const res = await axios.get(`${serverUrl}/SASjsApi/info`)
     if (res.data?.mode === 'server') {
       const clientId = await getClientId()
-      env.openExternal(Uri.parse(getAuthUrl(serverType, serverUrl, clientId)))
+      const authUrl = Uri.parse(getAuthUrl(serverType, serverUrl, clientId))
+      outputChannel.appendLine(authUrl.toString())
+      outputChannel.show()
+      env.openExternal(authUrl)
 
       const authCode = await getAuthCode()
 


### PR DESCRIPTION
### Issue
closes #333 

### Intent
* Show auth code URL in console window along with redirection. So, whenever there's a problem in redirection user can use the link printed in the console window.