### PR TITLE
feat: configurable sasjsresults and sasjsbuild folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@sasjs/adapter": "4.1.2",
         "@sasjs/cli": "3.28.0",
         "@sasjs/lint": "2.2.2",
-        "@sasjs/utils": "3.0.1",
+        "@sasjs/utils": "3.1.1",
         "axios": "0.26.1",
         "dotenv": "16.0.3",
         "esbuild-plugin-copy": "2.0.1",
@@ -692,6 +692,41 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@sasjs/cli/node_modules/@sasjs/utils": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.0.1.tgz",
+      "integrity": "sha512-0+4uUY3UPwTyl1Ll/HMJspihgEGggEIpJtd/NVIIZAfhODY4g1c8bLGkmQW6kASItPSkHDCiiW6ZUb0xTo5+4w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fast-csv/format": "4.3.5",
+        "@types/fs-extra": "9.0.13",
+        "@types/prompts": "2.0.13",
+        "chalk": "4.1.1",
+        "cli-table": "0.3.6",
+        "consola": "2.15.0",
+        "find": "0.3.0",
+        "fs-extra": "10.0.0",
+        "jwt-decode": "3.1.2",
+        "prompts": "2.4.1",
+        "rimraf": "3.0.2",
+        "valid-url": "1.0.9"
+      }
+    },
+    "node_modules/@sasjs/cli/node_modules/@sasjs/utils/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/@sasjs/cli/node_modules/axios": {
       "version": "0.27.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
@@ -777,9 +812,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-0+4uUY3UPwTyl1Ll/HMJspihgEGggEIpJtd/NVIIZAfhODY4g1c8bLGkmQW6kASItPSkHDCiiW6ZUb0xTo5+4w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-qSLOw3lkE1JnKeBljrb8E+c5tK3Ko/MUz7mRFu5rNw3zFz407Xff0v9UGK0cgyxXw4uEGU9eL+qWSe42b38OLA==",
       "hasInstallScript": true,
       "dependencies": {
         "@fast-csv/format": "4.3.5",
@@ -11708,6 +11743,36 @@
             }
           }
         },
+        "@sasjs/utils": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.0.1.tgz",
+          "integrity": "sha512-0+4uUY3UPwTyl1Ll/HMJspihgEGggEIpJtd/NVIIZAfhODY4g1c8bLGkmQW6kASItPSkHDCiiW6ZUb0xTo5+4w==",
+          "requires": {
+            "@fast-csv/format": "4.3.5",
+            "@types/fs-extra": "9.0.13",
+            "@types/prompts": "2.0.13",
+            "chalk": "4.1.1",
+            "cli-table": "0.3.6",
+            "consola": "2.15.0",
+            "find": "0.3.0",
+            "fs-extra": "10.0.0",
+            "jwt-decode": "3.1.2",
+            "prompts": "2.4.1",
+            "rimraf": "3.0.2",
+            "valid-url": "1.0.9"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+              "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            }
+          }
+        },
         "axios": {
           "version": "0.27.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
@@ -11778,9 +11843,9 @@
       }
     },
     "@sasjs/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-0+4uUY3UPwTyl1Ll/HMJspihgEGggEIpJtd/NVIIZAfhODY4g1c8bLGkmQW6kASItPSkHDCiiW6ZUb0xTo5+4w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.1.1.tgz",
+      "integrity": "sha512-qSLOw3lkE1JnKeBljrb8E+c5tK3Ko/MUz7mRFu5rNw3zFz407Xff0v9UGK0cgyxXw4uEGU9eL+qWSe42b38OLA==",
       "requires": {
         "@fast-csv/format": "4.3.5",
         "@types/fs-extra": "9.0.13",

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "@sasjs/adapter": "4.1.2",
     "@sasjs/cli": "3.28.0",
     "@sasjs/lint": "2.2.2",
-    "@sasjs/utils": "3.0.1",
+    "@sasjs/utils": "3.1.1",
     "axios": "0.26.1",
     "dotenv": "16.0.3",
     "esbuild-plugin-copy": "2.0.1",


### PR DESCRIPTION
BREAKING CHANGE: the config for specifying the output destinations has changed, and now both items are in the root rather than in the buildConfig.  For more info, see: https://github.com/sasjs/cli/issues/1320