### PR TITLE
feat: look for global .sasjslint file before using default setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Spend less time on code reviews and more time pushing code! Select VIEW->PROBLEM
 
 ![image](https://user-images.githubusercontent.com/4420615/113478713-800e1d00-9482-11eb-90c1-10a80a41be1a.png)
 
+### Rules
+
 Rules can be configured by creating a `.sasjslint` file in the root of your project as follows:
 
 ```json
@@ -112,10 +114,18 @@ Rules can be configured by creating a `.sasjslint` file in the root of your proj
     "maxLineLength": 80,
     "noNestedMacros": true,
     "noSpacesInFileNames": true,
-    "noTabIndentation": true,
+    "noTabs": true,
     "noTrailingSpaces": true
 }
 ```
+
+Settings in the project (workspace) root (`.sasjslint`) take the highest precedence, followed by the following locations:
+
+* VS Code (extension) settings (`sasjs-for-vscode.lintConfig`)
+* User Home directory (`~/.sasjslint`)
+* Default settings (see https://github.com/sasjs/lint#sas-lint-settings)
+
+### Formatting
 
 SASjs lint can automatically fix certain problems within SAS files, such as trailing spaces, missing Doxygen header blocks and missing macro names in `%mend` statements.
 You can use this feature in two ways:

--- a/src/utils/getLintConfig.ts
+++ b/src/utils/getLintConfig.ts
@@ -1,16 +1,22 @@
 import * as path from 'path'
+import * as os from 'os'
 import { workspace } from 'vscode'
 import { LintConfig, DefaultLintConfiguration } from '@sasjs/lint'
 import { readFile } from './file'
+import { fileExists } from '@sasjs/utils'
 
 export const getLintConfig = async () => {
   let config = DefaultLintConfiguration
 
-  const lintConfigPath = path.join(process.projectDir, '.sasjslint')
+  let lintConfigPath = path.join(os.homedir(), '.sasjslint')
+
+  if (await fileExists(path.join(process.projectDir, '.sasjslint'))) {
+    lintConfigPath = path.join(process.projectDir, '.sasjslint')
+  }
 
   await readFile(lintConfigPath)
     .then((content) => {
-      config = { ...config, ...JSON.parse(content) }
+      config = JSON.parse(content)
     })
     .catch(() => {
       const extConfig = workspace.getConfiguration('sasjs-for-vscode')


### PR DESCRIPTION
### Issue

sasjs/lint#209

### Intent

* look for the global .sasjslint file at ~/.sasjslint before using lint configuration from the extension's setting