### PR TITLE
Target url issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,15 +10,14 @@
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/adapter": "4.3.5",
-        "@sasjs/cli": "4.1.1",
+        "@sasjs/cli": "4.3.0",
         "@sasjs/lint": "2.3.1",
-        "@sasjs/utils": "3.2.0",
+        "@sasjs/utils": "3.3.0",
         "axios": "0.26.1",
         "dotenv": "16.0.3",
         "esbuild-plugin-copy": "2.0.1",
         "node-graphviz": "0.1.1",
-        "shelljs.exec": "1.1.8",
-        "valid-url": "1.0.9"
+        "shelljs.exec": "1.1.8"
       },
       "devDependencies": {
         "@types/glob": "^7.1.4",
@@ -27,7 +26,6 @@
         "@types/node": "^18.14.0",
         "@types/shelljs.exec": "1.1.0",
         "@types/tough-cookie": "^4.0.1",
-        "@types/valid-url": "^1.0.3",
         "@types/vscode": "^1.64.0",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
@@ -749,9 +747,9 @@
       }
     },
     "node_modules/@fast-csv/format/node_modules/@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ=="
+      "version": "14.18.47",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.47.tgz",
+      "integrity": "sha512-OuJi8bIng4wYHHA3YpKauL58dZrPxro3d0tabPHyiNF8rKfGKuVfr83oFlPLmKri1cX+Z3cJP39GXmnqkP11Gw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -1569,15 +1567,15 @@
       }
     },
     "node_modules/@sasjs/cli": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-4.1.1.tgz",
-      "integrity": "sha512-C/uUerpfiSCvrauq7GtZ74He0qPXBGzCuvr2MkYBImLDH7kq4JaBFR1h/64Vz3K0GsQRH1Ypd5MUUmG12THptA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-4.3.0.tgz",
+      "integrity": "sha512-LDObBUigusiBvq7SzkL49W5zel2YfjcmetdrftEnEdpWeVkVYYby77gJiW9iXdhrdVT+Hgrdubs6tA+RT0LskA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/adapter": "4.1.6",
+        "@sasjs/adapter": "4.3.4",
         "@sasjs/core": "4.45.4",
-        "@sasjs/lint": "2.2.2",
-        "@sasjs/utils": "3.2.0",
+        "@sasjs/lint": "2.3.0",
+        "@sasjs/utils": "3.3.0",
         "adm-zip": "0.5.9",
         "chalk": "4.1.2",
         "dotenv": "10.0.0",
@@ -1602,9 +1600,9 @@
       }
     },
     "node_modules/@sasjs/cli/node_modules/@sasjs/adapter": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.1.6.tgz",
-      "integrity": "sha512-G4zWAvG0vnVHs/SzLZIAaxkgYeABTJOkVoRgPcSBs0zJld6YUH1eXme/UU1+FzsR+eBSX+qffejhPA1NFeq4bQ==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.3.4.tgz",
+      "integrity": "sha512-hPLNPXqunbIXZY+rsRxwfiLehk8x9a0IG2/96geJqrgP4Xi705X2WqkTaCpJ+Lr9gFGk4PttdprokCl1yoHVNw==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -1651,9 +1649,9 @@
       }
     },
     "node_modules/@sasjs/cli/node_modules/@sasjs/lint": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.2.2.tgz",
-      "integrity": "sha512-s0E5O1bS7USZLyx7RjH8A5VDuZIrS1e5xYPVXx+N4KomlGntAOpAGiFS0kQmQ3XT0nmFPk/De+jEFD7089QX4A==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/lint/-/lint-2.3.0.tgz",
+      "integrity": "sha512-ac3l4RUf3+87tmi2VCebibxQNIdiyzJuRGErka/BKXu+F4pBhUG1Y8t0lNISLDk6fm5uJXHpYrR5zck8J5tCtQ==",
       "hasInstallScript": true,
       "dependencies": {
         "@sasjs/utils": "2.52.0",
@@ -1763,9 +1761,9 @@
       }
     },
     "node_modules/@sasjs/utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.2.0.tgz",
-      "integrity": "sha512-Hdt4t/ErAy9JeJAyH7sJ+tA3ipKYUwRAAWN1CGMG0+BK2/TUVjpPtP9xYCtKculzfHFadthNXTnFVTfe4D4MLw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/utils/-/utils-3.3.0.tgz",
+      "integrity": "sha512-ZJ+c2d/rEoF340Ay3TZrXO4c2ain7AvSzkRuKG2H2qxwIlQQTk/9Rbknmy0mo3Y/QRScBYl0Fw5xSZ8SMHjljg==",
       "hasInstallScript": true,
       "dependencies": {
         "@fast-csv/format": "4.3.5",
@@ -1964,17 +1962,6 @@
         "pretty-format": "^29.0.0"
       }
     },
-    "node_modules/@types/jsdom": {
-      "version": "20.0.1",
-      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
-      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "parse5": "^7.0.0"
-      }
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.11",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
@@ -2061,12 +2048,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
-    },
-    "node_modules/@types/valid-url": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@types/valid-url/-/valid-url-1.0.4.tgz",
-      "integrity": "sha512-msGTxAnOwsiKZ36i5h3eBfOsMfuh+vKMqwsepJAd56ov9b+F9yYbJuE3rFOznHScNMKPY/y6rXbtWkb5RhyHMg==",
-      "dev": true
     },
     "node_modules/@types/vscode": {
       "version": "1.75.1",
@@ -6178,102 +6159,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-environment-jsdom": {
-      "version": "29.5.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.5.0.tgz",
-      "integrity": "sha512-/KG8yEK4aN8ak56yFVdqFDzKNHgF4BAymCx2LbPNPsUshUlfAl0eX402Xm1pt+eoG9SLZEUVifqXtX8SK74KCw==",
-      "dev": true,
-      "dependencies": {
-        "@jest/environment": "^29.5.0",
-        "@jest/fake-timers": "^29.5.0",
-        "@jest/types": "^29.5.0",
-        "@types/jsdom": "^20.0.0",
-        "@types/node": "*",
-        "jest-mock": "^29.5.0",
-        "jest-util": "^29.5.0",
-        "jsdom": "^20.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jest-environment-jsdom/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.5.0.tgz",
@@ -6289,27 +6174,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-extended": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-3.2.4.tgz",
-      "integrity": "sha512-lSEYhSmvXZG/7YXI7KO3LpiUiQ90gi5giwCJNDMMsX5a+/NZhdbQF2G4ALOBN+KcXVT3H6FPVPohAuMXooaLTQ==",
-      "dev": true,
-      "dependencies": {
-        "jest-diff": "^29.0.0",
-        "jest-get-type": "^29.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "jest": ">=27.2.5"
-      },
-      "peerDependenciesMeta": {
-        "jest": {
-          "optional": true
-        }
       }
     },
     "node_modules/jest-get-type": {

--- a/package.json
+++ b/package.json
@@ -243,7 +243,6 @@
     "@types/node": "^18.14.0",
     "@types/shelljs.exec": "1.1.0",
     "@types/tough-cookie": "^4.0.1",
-    "@types/valid-url": "^1.0.3",
     "@types/vscode": "^1.64.0",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
@@ -263,14 +262,13 @@
   },
   "dependencies": {
     "@sasjs/adapter": "4.3.5",
-    "@sasjs/cli": "4.1.1",
+    "@sasjs/cli": "4.3.0",
     "@sasjs/lint": "2.3.1",
-    "@sasjs/utils": "3.2.0",
+    "@sasjs/utils": "3.3.0",
     "axios": "0.26.1",
     "dotenv": "16.0.3",
     "esbuild-plugin-copy": "2.0.1",
     "node-graphviz": "0.1.1",
-    "shelljs.exec": "1.1.8",
-    "valid-url": "1.0.9"
+    "shelljs.exec": "1.1.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
         "command": "sasjs-for-vscode.addRemoveComment",
         "key": "ctrl+alt+l",
         "mac": "cmd+/",
-        "win": "ctrl+/"
+        "win": "ctrl+/",
+        "when": "editorLangId == sas && isWorkspaceOpened"
       }
     ],
     "configuration": {

--- a/src/commands/compileBuildDeploy/compileBuildDeployCommand.ts
+++ b/src/commands/compileBuildDeploy/compileBuildDeployCommand.ts
@@ -122,7 +122,9 @@ export class CompileBuildDeployCommand extends TargetCommand {
         }
       }
 
-      if (isCBDFailed) return
+      if (isCBDFailed) {
+        return
+      }
 
       await build(target).catch((err) => {
         this.handleError(err, 'Build failed!')
@@ -130,7 +132,9 @@ export class CompileBuildDeployCommand extends TargetCommand {
         isCBDFailed = true
       })
 
-      if (isCBDFailed) return
+      if (isCBDFailed) {
+        return
+      }
 
       await deploy(target, isLocal).catch((err) => {
         this.handleError(err, 'Deploy failed!')

--- a/src/utils/spec/createTarget.spec.ts
+++ b/src/utils/spec/createTarget.spec.ts
@@ -1,0 +1,56 @@
+import * as inputModule from '../input'
+import * as authModule from '../auth'
+import { createTarget } from '../createTarget'
+import { ServerType } from '@sasjs/utils/types'
+import { saveToConfigFile } from '../config'
+import * as configModule from '../config'
+import { Target } from '@sasjs/utils/types'
+
+describe('createTarget', () => {
+  it('should save to config file created target', async () => {
+    const testTargetName = 'testTargetName'
+    jest
+      .spyOn(inputModule, 'getTargetName')
+      .mockImplementation(() => Promise.resolve(testTargetName))
+
+    const testServerUrl = 'http://localhost:5000'
+    jest
+      .spyOn(inputModule, 'getServerUrl')
+      .mockImplementation(() => Promise.resolve(testServerUrl))
+
+    const testServerType = ServerType.Sasjs
+    jest
+      .spyOn(inputModule, 'getServerType')
+      .mockImplementation(() => Promise.resolve(testServerType))
+
+    const mockedTargetJson = {
+      name: testTargetName,
+      serverUrl: testServerUrl,
+      serverType: testServerType,
+      appLoc: '/Public/app'
+    }
+    const mockedTarget = new Target(mockedTargetJson)
+
+    jest
+      .spyOn(authModule, 'authenticateTarget')
+      .mockImplementation(() => Promise.resolve(mockedTargetJson))
+
+    jest.spyOn(configModule, 'saveToConfigFile')
+
+    await createTarget().catch((err) => {})
+
+    const isLocal = false
+    const expectedCallArgument = {
+      serverType: mockedTarget.serverType,
+      name: mockedTarget.name,
+      serverUrl: mockedTarget.serverUrl,
+      appLoc: mockedTarget.appLoc,
+      deployConfig: mockedTarget.deployConfig
+    }
+
+    expect(saveToConfigFile).toHaveBeenCalledWith(
+      expect.objectContaining(expectedCallArgument),
+      isLocal
+    )
+  })
+})

--- a/src/utils/spec/input.spec.ts
+++ b/src/utils/spec/input.spec.ts
@@ -1,0 +1,54 @@
+import { getServerUrl } from '../input'
+import * as inputModule from '../input'
+import { asyncForEach } from '@sasjs/utils'
+import { validateServerUrl } from '@sasjs/utils/types/targetValidators'
+
+describe('getServerUrl', () => {
+  it('should resolve with valid server URL', async () => {
+    const validUrls = [
+      '',
+      'http://localhost',
+      'http://localhost:5000',
+      'https://localhost',
+      'https://localhost:5000',
+      'https://sasjs.io',
+      'https://sasjs.co.uk'
+    ]
+    let testNumber = 0
+
+    jest.spyOn(inputModule, 'getTextInput').mockImplementation(() => {
+      testNumber++
+
+      return Promise.resolve(validateServerUrl(validUrls[testNumber - 1]))
+    })
+
+    asyncForEach(validUrls, (validUrl) => {
+      expect(getServerUrl()).resolves.toEqual(validUrl)
+    })
+  })
+
+  it('should reject if server URL is invalid', async () => {
+    const validUrls = [
+      ' ',
+      'test:\\test',
+      'http:\\ww.test.com',
+      'sasjs.io',
+      'www.sasjs.io'
+    ]
+    let testNumber = 0
+
+    jest.spyOn(inputModule, 'getTextInput').mockImplementation(() => {
+      testNumber++
+
+      return Promise.resolve(validateServerUrl(validUrls[testNumber - 1]))
+    })
+
+    const expectedError = new Error(
+      'Invalid server URL: `serverUrl` should either be an empty string or a valid URL of the form http(s)://your-server.com(:port).'
+    )
+
+    asyncForEach(validUrls, () => {
+      expect(getServerUrl()).rejects.toEqual(expectedError)
+    })
+  })
+})


### PR DESCRIPTION
## Issue

- Server URL with port number was incorrectly added while target creation.
- Line commenting implemented in `@sasjs/vscode-extension` was not limited to `.sas` files only.

## Intent

- Fix adding server URL with a port number.
- Use `@sasjs/utils` for URL validation.
- Allow adding target with server URL equal to an empty string.
- Add unit tests.
- Limit `addRemoveComment` to be triggered only for `.sas` files.

## Implementation

- Removed `valid-url` dependency and bumped `@sasjs/cli` and `@sasjs/utils`.
- Handled authentication error in `src/utils/createTarget.ts` and covered with unit test.
- Changed logic of `getServerUrl` func and covered with unit test. 

## Checks

- [x] Code is formatted correctly (`npm run lint`).
- [x] All unit tests are passing (`npm run test:unit`).
- [x] Reviewer is assigned.