### PR TITLE
fix: bump to @sasjs/adapter 4.16.0  and @sasjs/cli 4.12.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@sasjs/adapter": "^4.14.0",
-        "@sasjs/cli": "^4.12.11",
+        "@sasjs/adapter": "^4.16.0",
+        "@sasjs/cli": "^4.12.14",
         "@sasjs/lint": "^2.4.1",
         "@sasjs/utils": "^3.4.0",
         "axios": "^1.12.2",
@@ -262,6 +262,7 @@
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2419,6 +2420,7 @@
       "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -2616,9 +2618,9 @@
       }
     },
     "node_modules/@sasjs/adapter": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.14.0.tgz",
-      "integrity": "sha512-kLjThuLayOr35A+MloXx4Z2tqjui48vHYmVXXmqiFe26Wal6i2jflzhVN5+srmYlGzJX+G0SN78kYTKfvr3lcA==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@sasjs/adapter/-/adapter-4.16.0.tgz",
+      "integrity": "sha512-DzF/+s++FtSfuBmONicBbgeKI8feiwDOm1iKWlcDlmHCPmHIoj1IbI0v2fGktzurnE37/vkyp6dvHO+FhwI87Q==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
@@ -2631,14 +2633,14 @@
       }
     },
     "node_modules/@sasjs/cli": {
-      "version": "4.12.11",
-      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-4.12.11.tgz",
-      "integrity": "sha512-s6iTbr9XmdeMreXdlIFFLrOjXWW9xOoV5AB7oMeSpw3mhlNV5EPh2BZMZAWTWgQ52038viiaaCzrTevMIJUsUQ==",
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/@sasjs/cli/-/cli-4.12.14.tgz",
+      "integrity": "sha512-aBPEfWmlSSQNGwRk53O3FF+g97OjnV83NmMp9G4dTh8ubDjsRivmChttoXHsLqkgy9VK2tmIv7rTMdQpcTU/rQ==",
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@sasjs/adapter": "4.14.0",
-        "@sasjs/core": "4.59.1",
+        "@sasjs/adapter": "^4.16.0",
+        "@sasjs/core": "4.59.7",
         "@sasjs/lint": "2.4.3",
         "@sasjs/utils": "3.5.2",
         "adm-zip": "0.5.10",
@@ -2672,9 +2674,9 @@
       }
     },
     "node_modules/@sasjs/core": {
-      "version": "4.59.1",
-      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.59.1.tgz",
-      "integrity": "sha512-52GNI4nIll5YivI8uobWrucE6TkHcTjcbKTr/YPC9eTauC4sh0V0MptebfAJ5E6vE5P2WevNZGr42KdDpckLpg==",
+      "version": "4.59.7",
+      "resolved": "https://registry.npmjs.org/@sasjs/core/-/core-4.59.7.tgz",
+      "integrity": "sha512-1sndZfmAhp0qAE+bprbFCCHBgTtGVMZ5y5gA830QhyLJPdjJ0IKTEYidR7J5563l72YMP5FWwehCOjqRXjKOaw==",
       "license": "MIT"
     },
     "node_modules/@sasjs/lint": {
@@ -3392,6 +3394,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.17.0.tgz",
       "integrity": "sha512-bbAKTCqX5aNVryi7qXVMi+OkB3w/OyblodicMbvE38blyAz7GxXf6XYhklokijuPwwVg9sDLKRxt0ZHXQwZVfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3506,6 +3509,7 @@
       "integrity": "sha512-g3WpVQHngx0aLXn6kfIYCZxM6rRJlWzEkVpqEFLT3SgEDsp9cpCbxxgwnE504q4H+ruSDh/VGS6nqZIDynP+vg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.39.0",
         "@typescript-eslint/types": "8.39.0",
@@ -4032,6 +4036,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4398,6 +4403,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
       "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -4710,6 +4716,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -6424,6 +6431,7 @@
       "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -6515,6 +6523,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8391,6 +8400,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9696,6 +9706,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -12776,6 +12787,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14493,6 +14505,7 @@
       "integrity": "sha512-D0cwjlO5RZzHHxAcsoF1HxiRLfC3ehw+ay+zntzFs6PNX6aV0JzKNG15mpxPipBYa/l4fHly88dHvgDyqwb1Ww==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.0-beta.1",
         "@semantic-release/error": "^4.0.0",
@@ -16002,6 +16015,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
       "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
@@ -16143,6 +16157,7 @@
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -16276,6 +16291,7 @@
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -280,8 +280,8 @@
     "vscode-test": "^1.6.1"
   },
   "dependencies": {
-    "@sasjs/adapter": "^4.14.0",
-    "@sasjs/cli": "^4.12.11",
+    "@sasjs/adapter": "^4.16.0",
+    "@sasjs/cli": "^4.12.14",
     "@sasjs/lint": "^2.4.1",
     "@sasjs/utils": "^3.4.0",
     "axios": "^1.12.2",


### PR DESCRIPTION
## Issue

New versions of the @sasjs/adapter and @sasjs/cli packages are available.

## Intent

Include the latest versions of @sasjs/adapter and @sasjs/cli.

## Implementation

Bump the `package.json` dependencies for @sasjs/adapter and @sasjs/cli.
Submit `npm i` to automatically update the `package-lock.json`

## Checks

- [ ] Code is formatted correctly (`npm run lint`).
- [ ] All unit tests are passing (`npm run test:unit`).
- [ ] Reviewer is assigned.
