### PR TITLE
chore: pin axios versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@sasjs/cli": "^4.12.14",
         "@sasjs/lint": "^2.4.1",
         "@sasjs/utils": "^3.4.0",
-        "axios": "^1.12.2",
+        "axios": "1.12.2",
         "dotenv": "16.4.7",
         "esbuild-plugin-copy": "2.1.1",
         "node-graphviz": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
     "@sasjs/cli": "^4.12.14",
     "@sasjs/lint": "^2.4.1",
     "@sasjs/utils": "^3.4.0",
-    "axios": "^1.12.2",
+    "axios": "1.12.2",
     "dotenv": "16.4.7",
     "esbuild-plugin-copy": "2.1.1",
     "node-graphviz": "0.1.1",


### PR DESCRIPTION
## Intent

Pin the `axios` version to prevent `npm install` on developer machines from pulling unwanted versions. Workflow actions are protected with `npm ci`.

## Implementation

Installed axios with `--save-exact` flag.